### PR TITLE
Tweak error in gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,8 +75,7 @@ task tagRelease << {
 
 task checkVersion << {
     if(version.endsWith("-SNAPSHOT")){
-        logger.error "################### Remove -SNAPSHOT ! ###################"
-        throw "Remove -SNAPSHOT !"
+        throw new GradleException("Remove '-SNAPSHOT' in version!")
     }
 }
 


### PR DESCRIPTION
ref. http://stackoverflow.com/questions/10312259/recommended-way-to-stop-a-build-with-gradle

```sh
$ ./gradlew checkVersion
Picked up _JAVA_OPTIONS: -Dfile.encoding=UTF-8
Parallel execution with configuration on demand is an incubating feature.
:checkVersion FAILED

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/sue445/dev/workspace/github.com/jenkinsci/yaml-axis-plugin/build.gradle' line: 78

* What went wrong:
Execution failed for task ':checkVersion'.
> Remove '-SNAPSHOT' of version!

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 44.963 secs
```