### PR TITLE
Suppress error

### DIFF
--- a/src/main/groovy/org/jenkinsci/plugins/yamlaxis/YamlAxis.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/yamlaxis/YamlAxis.groovy
@@ -32,6 +32,7 @@ class YamlAxis extends Axis {
             return computedValues
         }
 
+        // NOTE: Plugin can not get workspace location in this method
         YamlLoader loader = new YamlLoader(yamlFile: yamlFile)
 
         try {

--- a/src/main/groovy/org/jenkinsci/plugins/yamlaxis/YamlAxis.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/yamlaxis/YamlAxis.groovy
@@ -38,8 +38,8 @@ class YamlAxis extends Axis {
         try {
             computedValues = loader.loadValues(name)
             computedValues
-        } catch (IOException e){
-            LOGGER.log(Level.SEVERE, "Can not read yamlFile: ${yamlFile}", e)
+        } catch (IOException){
+            LOGGER.log(Level.SEVERE, "Can not read yamlFile: ${yamlFile}")
             []
         }
     }
@@ -52,8 +52,8 @@ class YamlAxis extends Axis {
         try {
             computedValues = loader.loadValues(name)
             computedValues
-        } catch (IOException e){
-            LOGGER.log(Level.SEVERE, "Can not read yamlFile: ${yamlFile}", e)
+        } catch (IOException){
+            LOGGER.log(Level.SEVERE, "Can not read yamlFile: ${yamlFile}")
             []
         }
     }


### PR DESCRIPTION
When using relative axis file path, error is always occurred in `YamlAxis#getValues()` .
Plugin can not get workspace location in `YamlAxis#getValues()`