### PR TITLE
Fix. UDP handling problem

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+systemProp.java.net.preferIPv4Stack=true


### PR DESCRIPTION
```
java.net.SocketException: Can't assign requested address
        at java.net.PlainDatagramSocketImpl.join(Native Method)
        at java.net.AbstractPlainDatagramSocketImpl.join(AbstractPlainDatagramSocketImpl.java:179)
        at java.net.MulticastSocket.joinGroup(MulticastSocket.java:323)
```