### PR TITLE
Restrict deep for yaml hierarchy 

### DIFF
--- a/src/main/groovy/org/jenkinsci/plugins/yamlaxis/YamlLoader.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/yamlaxis/YamlLoader.groovy
@@ -7,7 +7,12 @@ abstract class YamlLoader {
         if(values == null){
             return []
         }
-        values.collect { it.toString() }
+
+        if(values instanceof Map) {
+            values.keySet()
+        } else {
+            values.collect { it.toString() }
+        }
     }
 
     /**


### PR DESCRIPTION
At this moment plugin did handle all levels in yaml tree.
For example next yaml 
```yaml
root:
    a:
        nightly_check: true
   b:
        nightly_check: false
   c:
        nightly_check: true
```
will return for  ```Axis name (Top key of yaml)``` = root

```
[a={nightly_check=true}, b={nightly_check=false}, c={nightly_check=true}]
```
and configuration's names will be:

```
a={nightly_check=true}
b={nightly_check=false}
c={nightly_check=true}
```

Will be great if plugin will return:

```
[a,b,c]
```