### PR TITLE
Update groovy dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,11 +45,11 @@ repositories {
 }
 
 dependencies {
-    // NOTE: groovy version included in Jenkins is 1.8.9
-    runtime 'org.codehaus.groovy:groovy-all:1.8.9'
+    runtime 'org.codehaus.groovy:groovy-all:2.4.12'
+    compile 'org.codehaus.groovy:groovy-all:2.4.12'
     compile 'org.yaml:snakeyaml:1.26'
 
-    testCompile 'org.spockframework:spock-core:0.7-groovy-1.8'
+    testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
 
     jenkinsPlugins 'org.jenkins-ci.plugins:matrix-project:1.6@jar'
 }


### PR DESCRIPTION
The groovy version included in Jenkins is now 2.4.12 and the latest
version of the plugin no longer loads without updating these
dependencies. I'm not 100% sure this is the right way to do this, but it
does work :-)

See: https://issues.jenkins-ci.org/browse/JENKINS-61859.