### PR TITLE
[WEBSITE-757] Request image with HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 # Jenkins Yaml Axis Plugin
 Matrix project axis creation and exclusion plugin using yaml file
 
-[![Plugin Version](http://sebastian-badge.info/plugins/yaml-axis.svg)](https://wiki.jenkins-ci.org/display/JENKINS/Yaml+Axis+Plugin)
+[![Plugin Version](https://img.shields.io/jenkins/plugin/v/yaml-axis.svg)](https://github.com/jenkinsci/yaml-axis-plugin/blob/master/README.md)
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/yaml-axis-plugin/master)](https://ci.jenkins.io/job/Plugins/yaml-axis-plugin/master)
 
-* https://wiki.jenkins-ci.org/display/JENKINS/Yaml+Axis+Plugin
-* https://github.com/jenkinsci/yaml-axis-plugin
-
-## Usage
+# Usage
 ### 1. Add yaml file to repository
 example
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Matrix project axis creation and exclusion plugin using yaml file
 [![Plugin Version](https://img.shields.io/jenkins/plugin/v/yaml-axis.svg)](https://github.com/jenkinsci/yaml-axis-plugin/blob/master/README.md)
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/yaml-axis-plugin/master)](https://ci.jenkins.io/job/Plugins/yaml-axis-plugin/master)
 
-# Usage
+## Usage
 ### 1. Add yaml file to repository
 example
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Matrix project axis creation and exclusion plugin using yaml file
 
 [![Plugin Version](https://img.shields.io/jenkins/plugin/v/yaml-axis.svg)](https://github.com/jenkinsci/yaml-axis-plugin/blob/master/README.md)
-[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/yaml-axis-plugin/master)](https://ci.jenkins.io/job/Plugins/yaml-axis-plugin/master)
+[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/yaml-axis-plugin/master)](https://ci.jenkins.io/job/Plugins/job/yaml-axis-plugin/job/master/)
 
 ## Usage
 ### 1. Add yaml file to repository


### PR DESCRIPTION
[WEBSITE-757](https://issues.jenkins-ci.org/browse/WEBSITE-757) https://plugins.jenkins.io/yaml-axis will not serve an image over HTTPS that uses an HTTP URL.

Also removes reference to wiki page that immediately redirects to plugins.jenkins.io

Also removes reference to GitHub repository since that is already included in the plugins.jenkins.io page.