### PR TITLE
Allow for lists as values in excludes mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Generate yaml based matrix and run job :muscle:
 
 ## Detail
 ### Excluding logic
-Excluding pattern may be specified with `List` of `Map` (e.g. `List<Map<String, String>>`)
-
+Excluding pattern may be specified with `List` of `Map` (e.g. `List<Map<String, [String or List]>>`)
+Elements in the `Map` may be a List to exclude multiple items for one key
 ```yaml
 # axis.yml
 exclude:
@@ -71,7 +71,6 @@ exclude:
   - RUBY_VERSION: 2.3.0
     DATABASE: oracle
 ```
-
 When specified 2 axes
 
 ![axis](doc/axis.png)
@@ -86,3 +85,39 @@ This results in a 3x3 build matrix.
   * `RUBY_VERSION` value `2.1.8` and `DATABASE` value `oracle` is excluded
 * When specified `RUBY_VERSION` value `2.3.0` and `DATABASE` value `oracle`, 1 result is excluded
   * `RUBY_VERSION` value `2.3.0` and `DATABASE` value `oracle` is excluded
+
+#### Another example
+```yaml
+# axis2.yml
+exclude:
+  - RUBY_VERSION: 2.1.8
+  - RUBY_VERSION: 2.3.0
+    DATABASE: 
+      - oracle
+      - mysql
+```
+* When specified `RUBY_VERSION` value `2.1.8`, 3 results are excluded
+  * `RUBY_VERSION` value `2.1.8` and `DATABASE` value `mysql` is excluded
+  * `RUBY_VERSION` value `2.1.8` and `DATABASE` value `postgres` is excluded
+  * `RUBY_VERSION` value `2.1.8` and `DATABASE` value `oracle` is excluded
+* When specified `RUBY_VERSION` value `2.3.0`, 2 results are excluded
+  * `RUBY_VERSION` value `2.3.0` and `DATABASE` value `oracle` is excluded
+  * `RUBY_VERSION` value `2.3.0` and `DATABASE` value `mysql` is excluded
+
+#### Final example
+Using multiple lists will exclude the cartesian product of those lists.
+```yaml
+# axis3.yml
+exclude:
+  - RUBY_VERSION: 
+      - 2.1.8
+      - 2.3.0
+    DATABASE: 
+      - oracle
+      - mysql
+```
+* 4 results are excluded
+  * `RUBY_VERSION` value `2.1.8` and `DATABASE` value `mysql` is excluded
+  * `RUBY_VERSION` value `2.1.8` and `DATABASE` value `oracle` is excluded
+  * `RUBY_VERSION` value `2.3.0` and `DATABASE` value `oracle` is excluded
+  * `RUBY_VERSION` value `2.3.0` and `DATABASE` value `mysql` is excluded

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Generate yaml based matrix and run job :muscle:
 ## Detail
 ### Excluding logic
 Excluding pattern may be specified with `List` of `Map` (e.g. `List<Map<String, [String or List]>>`)
+
 Elements in the `Map` may be a List to exclude multiple items for one key
 ```yaml
 # axis.yml

--- a/src/main/groovy/org/jenkinsci/plugins/yamlaxis/YamlLoader.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/yamlaxis/YamlLoader.groovy
@@ -15,14 +15,21 @@ abstract class YamlLoader {
      * @param key
      * @return if key is not found, return null
      */
-    List<Map<String, String>> loadMaps(String key){
+    List<Map<String, ?>> loadMaps(String key){
         Map content = getContent()
         def values = content.get(key)
         if(values == null){
             return null
         }
         values.collect {
-            it.collectEntries { k, v -> [k, v.toString()] }
+            it.collectEntries { k, v ->
+                if(v instanceof List){
+                    [k, v.collect { it.toString() }]
+                }else{
+                    [k, v.toString()]
+                }
+             }
+
         }
     }
 

--- a/src/test/groovy/org/jenkinsci/plugins/yamlaxis/YamlMatrixExecutionStrategySpec.groovy
+++ b/src/test/groovy/org/jenkinsci/plugins/yamlaxis/YamlMatrixExecutionStrategySpec.groovy
@@ -30,7 +30,7 @@ class YamlMatrixExecutionStrategySpec extends Specification {
     def "run"() {
         setup:
         def matrixProject = configure()
-        List<Combination> excludeCombinations = excludes.collect { new Combination(it) }
+        List<Combination> excludeCombinations = YamlMatrixExecutionStrategy.collectExcludeCombinations(excludes)
         matrixProject.executionStrategy = new YamlMatrixExecutionStrategy(excludeCombinations)
         def build = matrixProject.scheduleBuild2(0).get()
 
@@ -40,9 +40,16 @@ class YamlMatrixExecutionStrategySpec extends Specification {
         build.runs.size() == runsCount
 
         where:
-        excludes                   || runsCount
-        []                         || 9
-        [[axis1: "c", axis2: "z"]] || 8
-        [[axis1: "c"]]             || 6
+        excludes                                 || runsCount
+        []                                       || 9
+        [[axis1: "c", axis2: "z"]]               || 8
+        [[axis1: "c", axis2: ["z"]]]             || 8
+        [[axis1: ["c"], axis2: "z"]]             || 8
+        [[axis1: ["c"], axis2: ["z"]]]           || 8
+        [[axis1: "c"]]                           || 6
+        [[axis1: ["b", "c"]]]                    || 3
+        [[axis1: "b"], [axis1: "c"]]             || 3
+        [[axis1: "b", axis2: ["x", "y"]]]        || 7
+        [[axis1: ["a", "b"], axis2: ["x", "y"]]] || 5
     }
 }

--- a/src/test/groovy/org/jenkinsci/plugins/yamlaxis/YamlTextLoaderSpock.groovy
+++ b/src/test/groovy/org/jenkinsci/plugins/yamlaxis/YamlTextLoaderSpock.groovy
@@ -52,4 +52,26 @@ exclude:
         "exclude"   || [[a: "1", b: "2"], [c: "3"]]
         "not_found" || null
     }
+
+    def "loadValuesList"(){
+        setup:
+        String yamlText = """
+exclude:
+  - a: 1
+    b:
+      - 2
+      - 3
+  - c: 4
+"""
+
+        def loader = new YamlTextLoader(yamlText: yamlText)
+
+        expect:
+        loader.loadMaps(key) == expected
+
+        where:
+        key         || expected
+        "exclude"   || [[a: "1", b: ["2", "3"]], [c: "4"]]
+        "not_found" || null
+    }
 }


### PR DESCRIPTION
Updates the excludes parsing so that values of the mappings can be either Strings or Lists. This allows for more concise and readable complex excludes. The original behavior (`Map<String, String>`) continues to work.

I updated the `README.md` and unit tests for the changes.

Examples (further details in readme changes):
```yaml
# axis2.yml
exclude:
  - RUBY_VERSION: 2.1.8
  - RUBY_VERSION: 2.3.0
    DATABASE: 
      - oracle
      - mysql
```

```yaml
# axis3.yml - cartesian product of both lists
exclude:
  - RUBY_VERSION: 
      - 2.1.8
      - 2.3.0
    DATABASE: 
      - oracle
      - mysql
```