### PR TITLE
Lower required Jenkins version to 2.414.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       day: "saturday"
       time: "05:00"
       timezone: "Asia/Tokyo"
+    exclude-patterns:
+      - "jenkins-core"
     assignees:
       - "sue445"
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <url>https://github.com/jenkinsci/yaml-axis-plugin</url>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.447</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
No reason to be strict about that. It prevents installing the plugin on older LTS versions.

### Testing done

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
