### PR TITLE
Enable and fix deprecation and unchecked warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,8 @@
                     <encoding>utf-8</encoding>
                     <source>11</source>
                     <target>11</target>
+                    <compilerArgument>-Xlint:deprecation</compilerArgument>
+                    <compilerArgument>-Xlint:unchecked</compilerArgument>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlAxis.java
+++ b/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlAxis.java
@@ -31,7 +31,7 @@ public class YamlAxis extends Axis {
     // NOTE: Plugin cannot get workspace location in this method
     YamlLoader loader = new YamlFileLoader(getYamlFile(), null);
     try {
-      computedValues = loader.loadStrings(name);
+      computedValues = loader.loadStrings(getName());
       return computedValues;
     } catch (Exception e) {
       return List.of();
@@ -43,7 +43,7 @@ public class YamlAxis extends Axis {
     FilePath workspace = context.getBuild().getModuleRoot();
     YamlLoader loader = new YamlFileLoader(getYamlFile(), workspace);
     try {
-      computedValues = loader.loadStrings(name);
+      computedValues = loader.loadStrings(getName());
       return computedValues;
     } catch (Exception e) {
       BuildUtils.log(context, "[WARN] Cannot read yamlFile: " + getYamlFile(), e);

--- a/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlFileLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlFileLoader.java
@@ -20,7 +20,7 @@ public class YamlFileLoader extends YamlLoader {
   }
 
   @Override
-  public Map getContent() {
+  public Map<String, Object> getContent() {
     if (Util.fixEmpty(yamlFile) == null) {
       return null;
     }

--- a/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlMatrixExecutionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlMatrixExecutionStrategy.java
@@ -76,6 +76,7 @@ public class YamlMatrixExecutionStrategy extends BaseMES {
     }
   }
 
+  @SuppressWarnings("unchecked")
   public static List<Combination> collectExcludeCombinations(List<Map<String, ?>> excludes) {
     List<Map<String, String>> result = new ArrayList<>();
     for (Map<String, ?> value : excludes) {
@@ -112,7 +113,7 @@ public class YamlMatrixExecutionStrategy extends BaseMES {
             }
           }
         }
-      } else {
+      } else if (value.values().stream().allMatch(v -> v instanceof String)) {
         combos.add((Map<String, String>) value);
       }
       result.addAll(combos);

--- a/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlTextLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlTextLoader.java
@@ -14,8 +14,8 @@ public class YamlTextLoader extends YamlLoader {
   }
 
   @Override
-  public Map getContent() {
+  public Map<String, Object> getContent() {
     Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
-    return (Map) yaml.load(yamlText);
+    return yaml.load(yamlText);
   }
 }


### PR DESCRIPTION
### Testing done

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

```
[WARNING] /home/audc/yaml-axis-plugin/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlAxis.java:[34,43] name in hudson.matrix.Axis has been deprecated
[WARNING] /home/audc/yaml-axis-plugin/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlAxis.java:[46,43] name in hudson.matrix.Axis has been deprecated
[WARNING] /home/audc/yaml-axis-plugin/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlMatrixExecutionStrategy.java:[116,42] unchecked cast
  required: java.util.Map<java.lang.String,java.lang.String>
  found:    java.util.Map<java.lang.String,capture#1 of ?>
[WARNING] /home/audc/yaml-axis-plugin/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlTextLoader.java:[17,14] getContent() in org.jenkinsci.plugins.yamlaxis.YamlTextLoader overrides getContent() in org.jenkinsci.plugins.yamlaxis.YamlLoader
  return type requires unchecked conversion from java.util.Map to java.util.Map<java.lang.String,java.lang.Object>
[WARNING] /home/audc/yaml-axis-plugin/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlFileLoader.java:[23,14] getContent() in org.jenkinsci.plugins.yamlaxis.YamlFileLoader overrides getContent() in org.jenkinsci.plugins.yamlaxis.YamlLoader
  return type requires unchecked conversion from java.util.Map to java.util.Map<java.lang.String,java.lang.Object>
```