### PR TITLE
Keep jenkins-core 2.414.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       timezone: "Asia/Tokyo"
     ignore:
       - dependency-name: "org.jenkins-ci.main:jenkins-core"
+
+      # Keep jenkins-core 2.414.3
+      - dependency-name: "org.jenkins-ci.plugins:matrix-project"
     assignees:
       - "sue445"
 


### PR DESCRIPTION
jenkins-core 2.434 has been required since matrix-project 830.v7ea_da_561b_a_34
https://github.com/jenkinsci/matrix-project-plugin/releases/tag/830.v7ea_da_561b_a_34

But I want to keep the current version because I am worried that raising the minimum version of Jenkins will have a big impact on plugin users.

e.g. #65

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
