### PR TITLE
Don't upgrade org.jenkins-ci.main:jenkins-test-harness in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
       # Keep jenkins-core 2.414.3
       - dependency-name: "org.jenkins-ci.plugins:matrix-project"
       - dependency-name: "org.jenkins-ci.plugins:plugin"
+      - dependency-name: "org.jenkins-ci.main:jenkins-test-harness"
     assignees:
       - "sue445"
 


### PR DESCRIPTION
Now `org.jenkins-ci.main:jenkins-test-harness` requires jenkins-core 2.479 
https://github.com/jenkinsci/jenkins-test-harness/releases/tag/2307.v10e5d0701b_e5

But I want to keep 2.414.3

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
