### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,15 @@
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
 buildPlugin(
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [ platform: "linux", jdk: "17" ],
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
   ],
   spotbugs: [
-    qualityGates: [[threshold: 100, type: 'NEW', unstable: false]]
-  ]
+      qualityGates: [[threshold: 100, type: 'NEW', unstable: false]]
+    ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.7</version>
     </parent>
 
     <artifactId>yaml-axis</artifactId>
@@ -14,7 +14,9 @@
     <url>https://github.com/jenkinsci/yaml-axis-plugin</url>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.414.3</jenkins.version>
+        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     </properties>
 
     <scm>
@@ -65,27 +67,26 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>4136.vca_c3202a_7fd1</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-core</artifactId>
-            <version>${jenkins.version}</version>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>822.824.v14451b_c0fd42</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>338.v848422169819</version>
-        </dependency>
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>2.3</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>snakeyaml-api</artifactId>
         </dependency>
 
         <dependency>
@@ -103,23 +104,12 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness</artifactId>
-            <version>2265.v3da_49c8134d6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <encoding>utf-8</encoding>
-                    <source>11</source>
-                    <target>11</target>
-                    <compilerArgument>-Xlint:deprecation</compilerArgument>
-                    <compilerArgument>-Xlint:unchecked</compilerArgument>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
@@ -176,7 +166,6 @@
             <!-- Only required if names of spec classes don't match default Surefire patterns (`*Test` etc.) -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.2</version>
                 <configuration>
                     <useFile>false</useFile>
                     <includes>
@@ -187,16 +176,6 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.8.3.0</version>
-                <executions>
-                    <execution>
-                        <id>check</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <xmlOutput>false</xmlOutput>
                     <failOnError>false</failOnError>

--- a/src/main/java/org/jenkinsci/plugins/yamlaxis/BaseMES.java
+++ b/src/main/java/org/jenkinsci/plugins/yamlaxis/BaseMES.java
@@ -65,7 +65,7 @@ abstract class BaseMES extends MatrixExecutionStrategy {
     return r;
   }
 
-  // override this and return a list of list of combinations
+  // override this and return a map of lists of combinations
   // and the builds will be run each inner list in parallel then do the next list
   // and if anything fails it stops
   abstract Map<String, List<Combination>> decideOrder(
@@ -82,7 +82,7 @@ abstract class BaseMES extends MatrixExecutionStrategy {
   }
 
   MatrixRun waitForCompletion(MatrixBuildExecution exec, MatrixConfiguration c)
-      throws InterruptedException, IOException {
+      throws InterruptedException {
     BuildListener listener = exec.getListener();
     String whyInQueue = "";
     long startTime = System.currentTimeMillis();

--- a/src/main/java/org/jenkinsci/plugins/yamlaxis/BaseMES.java
+++ b/src/main/java/org/jenkinsci/plugins/yamlaxis/BaseMES.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.yamlaxis;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.AbortException;
 import hudson.console.ModelHyperlinkNote;
 import hudson.matrix.*;
@@ -11,7 +12,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 // seems like groovy wants the abstract class too
 // import hudson.tasks.test.AggregatedTestResultAction

--- a/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlAxis.java
+++ b/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlAxis.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.yamlaxis;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.matrix.Axis;
@@ -7,6 +8,8 @@ import hudson.matrix.AxisDescriptor;
 import hudson.matrix.MatrixBuild;
 import hudson.util.FormValidation;
 import java.util.List;
+import java.util.Objects;
+
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.yamlaxis.util.BuildUtils;
 import org.jenkinsci.plugins.yamlaxis.util.DescriptorUtils;
@@ -15,7 +18,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
 
 public class YamlAxis extends Axis {
-  private List<String> computedValues = null;
+  private List<String> computedValues;
 
   @DataBoundConstructor
   public YamlAxis(String name, String valueString, List<String> computedValues) {
@@ -58,6 +61,7 @@ public class YamlAxis extends Axis {
   /** Descriptor for this plugin. */
   @Extension
   public static class DescriptorImpl extends AxisDescriptor {
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Yaml Axis";
@@ -65,7 +69,7 @@ public class YamlAxis extends Axis {
 
     /** Overridden to create a new instance of our Axis extension from UI values. */
     @Override
-    public Axis newInstance(StaplerRequest2 req, JSONObject formData) {
+    public Axis newInstance(StaplerRequest2 req, @NonNull JSONObject formData) {
       String name = formData.getString("name");
       String yamlFile = formData.getString("valueString");
       return new YamlAxis(name, yamlFile, null);
@@ -79,11 +83,8 @@ public class YamlAxis extends Axis {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof YamlAxis)) return false;
-    YamlAxis yamlAxis = (YamlAxis) o;
-    return computedValues != null
-        ? computedValues.equals(yamlAxis.computedValues)
-        : yamlAxis.computedValues == null;
+    if (!(o instanceof YamlAxis yamlAxis)) return false;
+    return Objects.equals(computedValues, yamlAxis.computedValues);
   }
 
   @Override

--- a/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlAxis.java
+++ b/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlAxis.java
@@ -12,7 +12,7 @@ import org.jenkinsci.plugins.yamlaxis.util.BuildUtils;
 import org.jenkinsci.plugins.yamlaxis.util.DescriptorUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 public class YamlAxis extends Axis {
   private List<String> computedValues = null;
@@ -65,7 +65,7 @@ public class YamlAxis extends Axis {
 
     /** Overridden to create a new instance of our Axis extension from UI values. */
     @Override
-    public Axis newInstance(StaplerRequest req, JSONObject formData) {
+    public Axis newInstance(StaplerRequest2 req, JSONObject formData) {
       String name = formData.getString("name");
       String yamlFile = formData.getString("valueString");
       return new YamlAxis(name, yamlFile, null);

--- a/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlMatrixExecutionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlMatrixExecutionStrategy.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.yamlaxis;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.matrix.Combination;
@@ -44,10 +45,10 @@ public class YamlMatrixExecutionStrategy extends BaseMES {
     List<Combination> excludeCombinations = loadExcludes(execution);
     List<Combination> combinations = MatrixUtils.reject(comb, excludeCombinations);
     BuildUtils.log(execution, "excludes=" + excludeCombinations);
-    return new HashMap<String, List<Combination>>() {
-      {
-        put("YamlMatrixExecutionStrategy", combinations);
-      }
+    return new HashMap<>() {
+	    {
+		    put("YamlMatrixExecutionStrategy", combinations);
+	    }
     };
   }
 
@@ -95,11 +96,11 @@ public class YamlMatrixExecutionStrategy extends BaseMES {
               }
             } else {
               newCombos.add(
-                  new HashMap<String, String>() {
-                    {
-                      put(entry.getKey(), (String) v);
-                    }
-                  });
+		              new HashMap<>() {
+			              {
+				              put(entry.getKey(), (String) v);
+			              }
+		              });
             }
           }
           combos = newCombos;
@@ -126,26 +127,26 @@ public class YamlMatrixExecutionStrategy extends BaseMES {
   }
 
   private YamlLoader getYamlLoader(MatrixBuild.MatrixBuildExecution execution) {
-    switch (yamlType) {
-      case YamlFileLoader.RADIO_VALUE:
-        FilePath workspace = execution.getBuild().getModuleRoot();
-        return new YamlFileLoader(yamlFile, workspace);
-      case YamlTextLoader.RADIO_VALUE:
-        return new YamlTextLoader(yamlText);
-      default:
-        throw new IllegalArgumentException(yamlType + " is unknown");
-    }
+	  return switch (yamlType) {
+		  case YamlFileLoader.RADIO_VALUE -> {
+			  FilePath workspace = execution.getBuild().getModuleRoot();
+			  yield new YamlFileLoader(yamlFile, workspace);
+		  }
+		  case YamlTextLoader.RADIO_VALUE -> new YamlTextLoader(yamlText);
+		  default -> throw new IllegalArgumentException(yamlType + " is unknown");
+	  };
   }
 
   @Extension
   public static class DescriptorImpl extends MatrixExecutionStrategyDescriptor {
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Yaml matrix execution strategy";
     }
 
     @Override
-    public YamlMatrixExecutionStrategy newInstance(StaplerRequest2 req, JSONObject formData) {
+    public YamlMatrixExecutionStrategy newInstance(StaplerRequest2 req, @NonNull JSONObject formData) {
       String yamlType = formData.getString("yamlType");
       String yamlFile = formData.getString("yamlFile");
       String yamlText = formData.getString("yamlText");

--- a/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlMatrixExecutionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlMatrixExecutionStrategy.java
@@ -16,7 +16,7 @@ import org.jenkinsci.plugins.yamlaxis.util.DescriptorUtils;
 import org.jenkinsci.plugins.yamlaxis.util.MatrixUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 public class YamlMatrixExecutionStrategy extends BaseMES {
   private String yamlType = YamlFileLoader.RADIO_VALUE;
@@ -145,7 +145,7 @@ public class YamlMatrixExecutionStrategy extends BaseMES {
     }
 
     @Override
-    public YamlMatrixExecutionStrategy newInstance(StaplerRequest req, JSONObject formData) {
+    public YamlMatrixExecutionStrategy newInstance(StaplerRequest2 req, JSONObject formData) {
       String yamlType = formData.getString("yamlType");
       String yamlFile = formData.getString("yamlFile");
       String yamlText = formData.getString("yamlText");


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Jenkins 2.479.1 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features
* Minor cleanup

### Testing done

`mvn clean verify`

### Submitter checklist
* [x]  Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x]  Ensure that the pull request title represents the desired changelog entry
* [x]  Please describe what you did
* [x]  Link to relevant issues in GitHub or Jira
* [x]  Link to relevant pull requests, esp. upstream and downstream changes
* [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue
