### PR TITLE
[JENKINS-744] Make JS compatible with Jenkins 2.539+ Content Security Policy

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/yamlaxis/YamlMatrixExecutionStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/yamlaxis/YamlMatrixExecutionStrategy/config.jelly
@@ -1,15 +1,5 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-  <script><![CDATA[
-    var YamlMatrixExecutionStrategy = {
-      // ref. https://issues.jenkins-ci.org/browse/JENKINS-15604
-      cmChange: function(editor, change){
-        editor.save();
-        $$('.validated').forEach(function (e) {e.onchange()})
-      }
-    }
-  ]]></script>
-
   <f:radioBlock checked="${instance.yamlTypeFile}" inline="true" name="yamlType" title="Yaml File" value="file">
     <f:entry title="yaml file" field="yamlFile">
       <f:textbox default="" />
@@ -17,8 +7,8 @@
   </f:radioBlock>
   <f:radioBlock checked="${instance.yamlTypeText}" inline="true" name="yamlType" title="Yaml Text" value="text">
     <f:entry title="yaml text" field="yamlText">
-      <f:textarea default="" codemirror-mode="yaml" codemirror-config="mode: 'text/x-yaml', onChange: YamlMatrixExecutionStrategy.cmChange"
-                  checkUrl="'descriptorByName/YamlMatrixExecutionStrategy/checkYamlText?value='+escape(this.value)"/>
+      <f:textarea default="" codemirror-mode="yaml" codemirror-config='mode: "text/x-yaml"'
+                  checkUrl="descriptorByName/YamlMatrixExecutionStrategy/checkYamlText" checkDependsOn=""/>
     </f:entry>
   </f:radioBlock>
 


### PR DESCRIPTION
See [JENKINS-74428](https://issues.jenkins.io/browse/JENKINS-74428) and [CSP developer docs](https://www.jenkins.io/doc/developer/security/csp/) (mostly [legacy checkUrl section](https://www.jenkins.io/doc/developer/security/csp/#legacy-javascript-checkurl-validation)).

The inline JS no longer works, since `$$` is no longer defined. I think this was from Prototype, which was removed in [Jenkins 2.426](https://www.jenkins.io/changelog/2.426/) ([announcement blog post](https://www.jenkins.io/blog/2023/05/12/removing-prototype-from-jenkins/)).

Since this apparently went unnoticed for a few years, I just removed the JS instead of figuring out a different solution.

### Testing done

`mvn hpi:run -Djenkins.version=2.480` (to get CSP-safe CodeMirror parsing in [2.480](https://www.jenkins.io/changelog/2.480/)), installed CSP plugin, and saw no findings anymore on the Matrix job config page.

Now the form field only updates when losing focus, consistent with other form fields in Jenkins.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
