### PR TITLE
Read yaml file on the agent node instead of the controller

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlFileLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/yamlaxis/YamlFileLoader.java
@@ -2,6 +2,8 @@ package org.jenkinsci.plugins.yamlaxis;
 
 import hudson.FilePath;
 import hudson.Util;
+import hudson.model.Executor;
+import hudson.remoting.VirtualChannel;
 import java.io.File;
 import java.io.InputStream;
 import java.util.Map;
@@ -32,10 +34,35 @@ public class YamlFileLoader extends YamlLoader {
     }
   }
 
-  private FilePath createFilePath() {
-    if (!Util.isRelativePath(yamlFile) || workspace == null) {
-      return new FilePath(new File(yamlFile));
+  // Package-private for testing (YamlFileLoaderChannelTest asserts the channel selection).
+  FilePath createFilePath() {
+    // A relative path is resolved against the workspace, which is bound to the node that ran the
+    // checkout (the agent). This case already read from the correct node.
+    if (workspace != null && Util.isRelativePath(yamlFile)) {
+      return new FilePath(workspace, yamlFile);
     }
-    return new FilePath(workspace, yamlFile);
+    // An absolute path (or one with no workspace) must NOT be read via new FilePath(new File(...)),
+    // which has a null channel and therefore always reads on the Jenkins controller JVM. Read it
+    // through the channel of the node that holds the workspace / runs the current build instead, so
+    // an absolute path points at the agent's filesystem rather than the controller's.
+    VirtualChannel channel = resolveChannel();
+    if (channel != null) {
+      return new FilePath(channel, yamlFile);
+    }
+    return new FilePath(new File(yamlFile));
+  }
+
+  /**
+   * Best-effort channel of the node that should serve the file: the workspace's channel when a
+   * workspace is available (agent channel for an agent-bound workspace, otherwise the controller's
+   * local channel), falling back to the channel of the current build's executor. Returns {@code
+   * null} when neither is available so the caller can default to the controller-local filesystem.
+   */
+  private VirtualChannel resolveChannel() {
+    if (workspace != null) {
+      return workspace.getChannel();
+    }
+    Executor executor = Executor.currentExecutor();
+    return executor != null ? executor.getOwner().getChannel() : null;
   }
 }

--- a/src/test/java/org/jenkinsci/plugins/yamlaxis/YamlFileLoaderChannelTest.java
+++ b/src/test/java/org/jenkinsci/plugins/yamlaxis/YamlFileLoaderChannelTest.java
@@ -1,0 +1,50 @@
+package org.jenkinsci.plugins.yamlaxis;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import hudson.FilePath;
+import hudson.remoting.VirtualChannel;
+import hudson.slaves.DumbSlave;
+import java.io.File;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Regression tests for reading the yaml file on the node that owns the workspace (typically an
+ * agent) instead of on the Jenkins controller.
+ *
+ * <p>Both cases fail against the previous implementation, which read an absolute path via {@code new
+ * FilePath(new File(yamlFile))} — a null-channel {@link FilePath} that always resolves on the
+ * controller JVM.
+ */
+@WithJenkins
+@DisplayName("YamlFileLoader resolves on the workspace's node, not the controller")
+class YamlFileLoaderChannelTest {
+
+  @Test
+  @DisplayName("an absolute path is resolved through the agent channel, not the controller")
+  void absolutePathUsesWorkspaceChannel(JenkinsRule j) throws Exception {
+    DumbSlave agent = j.createOnlineSlave();
+    VirtualChannel agentChannel = agent.getChannel();
+    FilePath workspace = new FilePath(agentChannel, agent.getRemoteFS());
+
+    String absolute = new File(agent.getRemoteFS(), "axis.yml").getAbsolutePath();
+    YamlFileLoader loader = new YamlFileLoader(absolute, workspace);
+
+    assertSame(agentChannel, loader.createFilePath().getChannel());
+  }
+
+  @Test
+  @DisplayName("a relative path stays resolved against the agent workspace channel")
+  void relativePathUsesWorkspaceChannel(JenkinsRule j) throws Exception {
+    DumbSlave agent = j.createOnlineSlave();
+    VirtualChannel agentChannel = agent.getChannel();
+    FilePath workspace = new FilePath(agentChannel, agent.getRemoteFS());
+
+    YamlFileLoader loader = new YamlFileLoader("axis.yml", workspace);
+
+    assertSame(agentChannel, loader.createFilePath().getChannel());
+  }
+}


### PR DESCRIPTION
YamlFileLoader read an absolute yamlFile (or any path when the workspace was null) via `new FilePath(new File(yamlFile))`. That FilePath has a null channel, so read() always resolves on the Jenkins controller JVM. When the matrix *parent* build runs on an agent, the file was therefore looked up on the controller rather than on the agent that ran the SCM checkout, and could not be found.

Resolve such paths through the channel of the node that owns the workspace (or, failing that, the current build's executor), so an absolute path targets the agent filesystem. This mirrors the fix in jenkinsci/matrix-groovy-execution-strategy-plugin@b77f030 (thr.getOwner().getChannel() + new FilePath(channel, path)).

Relative paths were already resolved against the agent-bound workspace FilePath and are unchanged. The fix also covers YamlMatrixExecutionStrategy (excludes), which shares createFilePath().

<!-- Please describe your pull request here. -->

### Testing done

A test for this change is included in the PR.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
