### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <jenkins.baseline>2.479</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
+        <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     </properties>
 
     <scm>
@@ -73,6 +74,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/yamlaxis/util/BuildUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/yamlaxis/util/BuildUtils.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.yamlaxis.util;
 
 import hudson.matrix.MatrixBuild;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public final class BuildUtils {
   private BuildUtils() {}

--- a/src/main/java/org/jenkinsci/plugins/yamlaxis/util/DescriptorUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/yamlaxis/util/DescriptorUtils.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.yamlaxis.util;
 
 import hudson.util.FormValidation;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public final class DescriptorUtils {
 


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Lang 3.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed
- `StringUtils` and `exception.ExceptionUtils` move to `org.apache.commons.lang3`. `ExceptionUtils`
  has no clean Java Platform equivalent, so this adds the `commons-lang3-api` library plugin
  (versionless — the version comes from the Jenkins plugin BOM).
- Enabled the `ban-commons-lang-2` enforcer rule to prevent regressions.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
